### PR TITLE
Add an Intl function for formatting price

### DIFF
--- a/src/currency.js
+++ b/src/currency.js
@@ -1,0 +1,8 @@
+function convertToDollars(value) {
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+    }).format(value);
+}
+
+export default convertToDollars;

--- a/src/views/DeployPage/DeployPage.jsx
+++ b/src/views/DeployPage/DeployPage.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import convertToDollars from '../../currency';
 
 function DeployPage({ onSubmit, pricing, products, regions }) {
     return (
@@ -44,10 +45,10 @@ function DeployPage({ onSubmit, pricing, products, regions }) {
                             <input
                                 aria-label="nodes"
                                 className="flex-grow mr-4"
-                                type="range"
                                 name="nodes"
                                 min={0}
                                 max={999}
+                                type="range"
                             />
                             <span>Show slider value here</span>
                         </div>
@@ -66,7 +67,7 @@ function DeployPage({ onSubmit, pricing, products, regions }) {
                         className="font-bold text-2xl"
                         role="region"
                     >
-                        ${pricing.default.cr0}
+                        {convertToDollars(pricing.default.cr0)}
                     </div>
                     <div className="flex py-4">
                         <button

--- a/src/views/DeployPage/DeployPage.test.jsx
+++ b/src/views/DeployPage/DeployPage.test.jsx
@@ -3,12 +3,10 @@ import { render } from '@testing-library/react';
 import DeployPage from './DeployPage';
 import { PRICING, PRODUCTS, REGIONS } from '../../data';
 
-const onSubmitSpy = jest.fn();
-
 const setup = () => {
     return render(
         <DeployPage
-            onSubmit={onSubmitSpy}
+            onSubmit={jest.fn()}
             pricing={PRICING}
             products={PRODUCTS}
             regions={REGIONS}


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Add an Intl function for formatting price
- Also small tidy-ups to test and props ordering in the view

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
